### PR TITLE
Add react-three dependencies to client/package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@react-three/drei": "latest",
+    "@react-three/fiber": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "three": "latest"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
### Motivation
- Add 3D rendering libraries so the client can import and use `Canvas`, `useFrame`, `Line`, `Points`, and `PointMaterial` from `@react-three/fiber` and `@react-three/drei`.

### Description
- Updated `client/package.json` to add `@react-three/fiber`, `@react-three/drei`, and `three` as dependencies (pinned to `"latest"`).

### Testing
- Ran `npm install` in `client/`, which failed with `E403 Forbidden` from the npm registry, so packages were not downloaded and no lockfile was produced.
- Ran a module resolution check with `node -e` which reported `@react-three/fiber`, `@react-three/drei`, and `three` as missing because the install did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adc19ef710832da58a1cbd25679064)