### PR TITLE
Add animated network canvas background layer

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,5 +1,37 @@
 @import url('https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;700&family=Cinzel:wght@500;700&display=swap');
 
+
+.app {
+  position: relative;
+  min-height: 100vh;
+  isolation: isolate;
+}
+
+.network-background {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.network-background::before,
+.network-background::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.network-background::before {
+  background: radial-gradient(circle at 25% 20%, rgba(120, 220, 255, 0.16), transparent 45%),
+    radial-gradient(circle at 75% 80%, rgba(110, 120, 255, 0.14), transparent 42%);
+}
+
+.network-background::after {
+  backdrop-filter: blur(1.4px);
+  background: linear-gradient(140deg, rgba(7, 10, 28, 0.2), rgba(2, 5, 18, 0.5));
+}
+
 :root {
   --night: #0d0b1a;
   --plum: #32134c;
@@ -11,13 +43,15 @@
 body {
   background: radial-gradient(circle at top, rgba(120, 90, 200, 0.25), transparent 45%),
     radial-gradient(circle at bottom, rgba(20, 140, 220, 0.25), transparent 50%),
-    linear-gradient(160deg, var(--night) 0%, #1a102b 50%, rgba(14, 25, 55, 0.85) 100%);
+    linear-gradient(160deg, #03040d 0%, var(--night) 40%, #1a102b 70%, rgba(14, 25, 55, 0.88) 100%);
   min-height: 100vh;
   color: #f5f4ff;
   font-family: 'Barlow', 'Segoe UI', sans-serif;
 }
 
 .app-shell {
+  position: relative;
+  z-index: 2;
   padding: 2rem 5vw 4rem;
   display: flex;
   flex-direction: column;

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,26 +1,30 @@
 import React from 'react';
 import './App.css';
 import GameBoard from './components/GameBoard';
+import NetworkBackground from './components/NetworkBackground';
 
 function App() {
   return (
-    <div className="app-shell">
-      <header className="app-header">
-        <h1>Canine Conflux</h1>
-        <p>
-          Command a pack of legendary dogs, weave spells, and outwit your rival in this
-          turn-based fantasy card duel.
-        </p>
-      </header>
-      <main>
-        <GameBoard />
-      </main>
-      <footer className="app-footer">
-        <p>
-          Inspired by trading card classics. Built for showcasing interactions and playful UI
-          storytelling.
-        </p>
-      </footer>
+    <div className="app">
+      <NetworkBackground />
+      <div className="app-shell">
+        <header className="app-header">
+          <h1>Canine Conflux</h1>
+          <p>
+            Command a pack of legendary dogs, weave spells, and outwit your rival in this
+            turn-based fantasy card duel.
+          </p>
+        </header>
+        <main>
+          <GameBoard />
+        </main>
+        <footer className="app-footer">
+          <p>
+            Inspired by trading card classics. Built for showcasing interactions and playful UI
+            storytelling.
+          </p>
+        </footer>
+      </div>
     </div>
   );
 }

--- a/client/src/components/NetworkBackground.js
+++ b/client/src/components/NetworkBackground.js
@@ -1,0 +1,156 @@
+import React, { useMemo, useRef } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Points, PointMaterial } from '@react-three/drei';
+
+const GRID_X = 42;
+const GRID_Z = 28;
+const SPACING = 0.48;
+const POINT_COUNT = GRID_X * GRID_Z;
+const CONNECTION_DISTANCE = 0.72;
+const MAX_CONNECTIONS = POINT_COUNT * 8;
+
+function NetworkField() {
+  const pointsRef = useRef();
+  const lineGeometryRef = useRef();
+  const frameCounterRef = useRef(0);
+
+  const basePositions = useMemo(() => {
+    const positions = new Float32Array(POINT_COUNT * 3);
+    const offsetX = ((GRID_X - 1) * SPACING) / 2;
+    const offsetZ = ((GRID_Z - 1) * SPACING) / 2;
+
+    let idx = 0;
+    for (let x = 0; x < GRID_X; x += 1) {
+      for (let z = 0; z < GRID_Z; z += 1) {
+        positions[idx] = x * SPACING - offsetX;
+        positions[idx + 1] = 0;
+        positions[idx + 2] = z * SPACING - offsetZ;
+        idx += 3;
+      }
+    }
+
+    return positions;
+  }, []);
+
+  const dynamicPositions = useMemo(() => new Float32Array(basePositions), [basePositions]);
+
+  const linePositions = useMemo(() => new Float32Array(MAX_CONNECTIONS * 6), []);
+
+  const connectionPairs = useMemo(() => {
+    const pairs = [];
+    for (let x = 0; x < GRID_X; x += 1) {
+      for (let z = 0; z < GRID_Z; z += 1) {
+        const current = x * GRID_Z + z;
+        if (x + 1 < GRID_X) pairs.push([current, (x + 1) * GRID_Z + z]);
+        if (z + 1 < GRID_Z) pairs.push([current, x * GRID_Z + (z + 1)]);
+        if (x + 1 < GRID_X && z + 1 < GRID_Z) pairs.push([current, (x + 1) * GRID_Z + (z + 1)]);
+        if (x - 1 >= 0 && z + 1 < GRID_Z) pairs.push([current, (x - 1) * GRID_Z + (z + 1)]);
+      }
+    }
+    return pairs;
+  }, []);
+
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime();
+
+    for (let i = 0; i < POINT_COUNT; i += 1) {
+      const ptr = i * 3;
+      const baseX = basePositions[ptr];
+      const baseZ = basePositions[ptr + 2];
+
+      dynamicPositions[ptr] = baseX;
+      dynamicPositions[ptr + 1] =
+        Math.sin(t * 0.7 + i * 0.22 + baseX * 0.25) * 0.085 +
+        Math.cos(t * 0.45 + baseZ * 0.4) * 0.035;
+      dynamicPositions[ptr + 2] = baseZ + Math.cos(t * 0.6 + i * 0.14 + baseX * 0.2) * 0.06;
+    }
+
+    if (pointsRef.current?.geometry?.attributes?.position) {
+      pointsRef.current.geometry.attributes.position.needsUpdate = true;
+    }
+
+    frameCounterRef.current += 1;
+    if (frameCounterRef.current % 2 !== 0) {
+      return;
+    }
+
+    let write = 0;
+    for (let p = 0; p < connectionPairs.length && write < MAX_CONNECTIONS; p += 1) {
+      const [a, b] = connectionPairs[p];
+      const aPtr = a * 3;
+      const bPtr = b * 3;
+
+      const dx = dynamicPositions[aPtr] - dynamicPositions[bPtr];
+      const dy = dynamicPositions[aPtr + 1] - dynamicPositions[bPtr + 1];
+      const dz = dynamicPositions[aPtr + 2] - dynamicPositions[bPtr + 2];
+
+      if (Math.sqrt(dx * dx + dy * dy + dz * dz) <= CONNECTION_DISTANCE) {
+        const linePtr = write * 6;
+        linePositions[linePtr] = dynamicPositions[aPtr];
+        linePositions[linePtr + 1] = dynamicPositions[aPtr + 1];
+        linePositions[linePtr + 2] = dynamicPositions[aPtr + 2];
+        linePositions[linePtr + 3] = dynamicPositions[bPtr];
+        linePositions[linePtr + 4] = dynamicPositions[bPtr + 1];
+        linePositions[linePtr + 5] = dynamicPositions[bPtr + 2];
+        write += 1;
+      }
+    }
+
+    if (lineGeometryRef.current?.attributes?.position) {
+      lineGeometryRef.current.setDrawRange(0, write * 2);
+      lineGeometryRef.current.attributes.position.needsUpdate = true;
+    }
+  });
+
+  return (
+    <group position={[0, -0.45, -0.9]}>
+      <lineSegments frustumCulled={false}>
+        <bufferGeometry ref={lineGeometryRef}>
+          <bufferAttribute
+            attach="attributes-position"
+            count={linePositions.length / 3}
+            array={linePositions}
+            itemSize={3}
+          />
+        </bufferGeometry>
+        <lineBasicMaterial
+          color="#7ac7ff"
+          transparent
+          opacity={0.22}
+          blending={2}
+          depthWrite={false}
+        />
+      </lineSegments>
+
+      <Points ref={pointsRef} positions={dynamicPositions} stride={3} frustumCulled={false}>
+        <PointMaterial
+          transparent
+          color="#dbf9ff"
+          size={0.03}
+          sizeAttenuation
+          opacity={0.85}
+          blending={2}
+          depthWrite={false}
+        />
+      </Points>
+    </group>
+  );
+}
+
+function NetworkBackground() {
+  return (
+    <div className="network-background" aria-hidden="true">
+      <Canvas
+        dpr={[1, 1.5]}
+        camera={{ position: [0, 0, 8], fov: 50, near: 0.1, far: 40 }}
+        gl={{ antialias: true, alpha: true, powerPreference: 'high-performance' }}
+      >
+        <color attach="background" args={['#060713']} />
+        <fog attach="fog" args={['#060713', 6, 18]} />
+        <NetworkField />
+      </Canvas>
+    </div>
+  );
+}
+
+export default NetworkBackground;


### PR DESCRIPTION
### Motivation
- Provide a subtle, performant animated background that enhances the UI with a flowing network/net effect while keeping gameplay UI and interactions fully accessible above it.

### Description
- Add `client/src/components/NetworkBackground.js` which mounts a `Canvas` (camera at `[0,0,8]`, `dpr` clamped) and implements a memoized grid of base positions stored in a `Float32Array` with per-frame wave motion in `useFrame` that perturbs Y/Z using sine/cosine and time.
- Implement connection logic that rebuilds a line segment buffer from nearby neighbor pairs each frame (or at a short interval) and renders lines with additive blending and low opacity for a luminous net effect, and render nodes with `Points`/`PointMaterial` as small cyan/white glowing points.
- Mount the background behind the app UI by updating `client/src/App.js` to wrap the shell with a top-level background element and add `aria-hidden` + CSS `pointer-events: none` to preserve accessibility and gameplay interactions.
- Update `client/src/App.css` with full-viewport dark gradient/background, z-index layering for `.network-background` and `.app-shell`, and subtle blur/glow overlay styles to approximate the reference look.

### Testing
- Ran `npm run build` in `client/` to validate the bundle, which failed due to unresolved `@react-three/fiber` in this environment before dependencies were installed.
- Attempted `npm install` in `client/` to restore packages, which failed with a `403 Forbidden` from the package registry in this environment so dependencies could not be installed.
- Attempted a Playwright screenshot against `http://127.0.0.1:3000` which failed with `ERR_EMPTY_RESPONSE` because the app could not be started without installing dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adc245bee8832db6a7b08d8e71841a)